### PR TITLE
Fix error: ZeroDivisionError: divided by 0 (ZeroDivisionError)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -8,16 +8,16 @@ Sentry.init do |config|
   config.debug = true # Enable debug mode for testing
 end
 
-def divide_by_zero
-  1 / 0
+def divide_by_zero(divisor)
+  raise ZeroDivisionError, 'Cannot divide by zero' if divisor == 0
+  1 / divisor
 end
-
 def main
   puts "Starting the app..."
   Sentry.capture_message("App started")
 
   begin
-    divide_by_zero
+    divide_by_zero(0)
   rescue ZeroDivisionError => e
     Sentry.capture_exception(e)
     puts "Caught an error: #{e.message}"


### PR DESCRIPTION
The error is caused by dividing by zero in the divide_by_zero function. We'll modify the function to avoid the division by zero and demonstrate error handling.